### PR TITLE
Added ability to get the result of DECL_ORIGINAL_TYPE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ $(PLUGIN_DSO): $(PLUGIN_OBJECT_FILES) $(LIBGCC_C_API_SO)
 	    -lgcc-c-api -Lgcc-c-api -Wl,-rpath=$(GCCPLUGINS_DIR)
 
 $(LIBGCC_C_API_SO):
-	cd gcc-c-api && make libgcc-c-api.so CC=$(CC)
+	cd gcc-c-api && make -e libgcc-c-api.so CC=$(CC)
 
 $(PLUGIN_OBJECT_GENERATED_FILES): CPPFLAGS+= $(if $(srcdir),-I$(srcdir))
 

--- a/gcc-python-pretty-printer.c
+++ b/gcc-python-pretty-printer.c
@@ -86,12 +86,16 @@ PyGccPrettyPrinter_as_string(PyObject *obj)
 
     /* Convert to a python string, leaving off the trailing newline: */
     len = strlen(ppobj->buf);
-    assert(len > 0);
-    if ('\n' == ppobj->buf[len - 1]) {
-	return PyGccString_FromString_and_size(ppobj->buf,
-						      len - 1);
-    } else {
-	return PyGccString_FromString(ppobj->buf);
+    if (len > 0) {
+      if ('\n' == ppobj->buf[len - 1]) {
+	  return PyGccString_FromString_and_size(ppobj->buf,
+							len - 1);
+      } else {
+	  return PyGccString_FromString(ppobj->buf);
+      }
+    }
+    else { /* FIXME: */
+      return PyGccString_FromString("");
     }
 }
 

--- a/gcc-python-tree.c
+++ b/gcc-python-tree.c
@@ -765,6 +765,17 @@ PyGccTypeDecl_get_pointer(struct PyGccTree *self, void *closure)
 }
 
 PyObject *
+PyGccTypeDecl_get_original_type(struct PyGccTree *self, void *closure)
+{
+    tree decl_type = TREE_TYPE(self->t.inner);
+    if (!decl_type) {
+        PyErr_SetString(PyExc_ValueError, "gcc.TypeDecl has no associated type");
+        return NULL;
+    }
+    return PyGccTree_New(gcc_private_make_tree(DECL_ORIGINAL_TYPE(TYPE_NAME(decl_type))));
+}
+
+PyObject *
 PyGccSsaName_repr(struct PyGccTree * self)
 {
     int version;

--- a/gcc-python-tree.c
+++ b/gcc-python-tree.c
@@ -1172,6 +1172,12 @@ gcc_tree_list_of_pairs_from_tree_list_chain(tree t)
 }
 
 PyObject *
+PyGcc_TreeMakeListOfPairsFromTreeListChain(tree t)
+{
+    return gcc_tree_list_of_pairs_from_tree_list_chain(t);
+}
+
+PyObject *
 VEC_tree_as_PyList(
 #if (GCC_VERSION >= 4008)
     vec<tree, va_gc> *vec_nodes

--- a/gcc-python-wrappers.h
+++ b/gcc-python-wrappers.h
@@ -299,6 +299,9 @@ PyObject *
 PyGccTypeDecl_get_pointer(struct PyGccTree *self, void *closure);
 
 PyObject *
+PyGccTypeDecl_get_original_type(struct PyGccTree *self, void *closure);
+
+PyObject *
 PyGccSsaName_repr(struct PyGccTree * self);
 
 PyObject *

--- a/generate-tree-c.py
+++ b/generate-tree-c.py
@@ -491,7 +491,7 @@ def generate_tree_code_classes():
     
         if tree_type.SYM == 'ENUMERAL_TYPE':
             add_simple_getter('values',
-                              'PyGcc_TreeListFromChain(TYPE_VALUES(self->t.inner))',
+                              'PyGcc_TreeMakeListOfPairsFromTreeListChain(TYPE_VALUES(self->t.inner))',
                               "The values of this type")
 
         if tree_type.SYM == 'IDENTIFIER_NODE':

--- a/generate-tree-c.py
+++ b/generate-tree-c.py
@@ -533,6 +533,10 @@ def generate_tree_code_classes():
                                   'PyGccTypeDecl_get_pointer',
                                   None,
                                   "The gcc.PointerType representing '(this_type *)'")
+            getsettable.add_gsdef('original_type',
+                                  'PyGccTypeDecl_get_original_type',
+                                  None,
+                                  "The gcc.Type from which this type was typedef'd from.'")
 
         if tree_type.SYM == 'FUNCTION_TYPE':
             getsettable.add_gsdef('argument_types',

--- a/generate-tree-c.py
+++ b/generate-tree-c.py
@@ -538,6 +538,11 @@ def generate_tree_code_classes():
                                   None,
                                   "The gcc.Type from which this type was typedef'd from.'")
 
+        if tree_type.SYM == 'FIELD_DECL':
+            add_simple_getter('addressable',
+                              'PyBool_FromLong(!DECL_NONADDRESSABLE_P(self->t.inner))',
+                              'The list of gcc.Declarations within this namespace')
+
         if tree_type.SYM == 'FUNCTION_TYPE':
             getsettable.add_gsdef('argument_types',
                                   'PyGccFunction_TypeObj_get_argument_types',


### PR DESCRIPTION
TypeDecl now has a "original_type" attribute which evaluates to the
outcome of DECL_ORIGINAL_TYPE(TYPE_NAME(t)).

I needed this because when a statement such as:

typedef struct foo bar;

appeared, there was no way to know what foo was, since the TypeDecl instance's "type" attribute was the type for bar, and not for foo. After reading a bit about gcc plugin internals, I realized I was supposed to get foo from bar via the macro DECL_ORIGINAL_TYPE (which follows the typedef chain upwards). So I added an "original_type" attribute to the TypeDecl instances, by immitating what was done with the "pointer" attribute.
