### PR TITLE
gcc 4.9 changes

### DIFF
--- a/gcc-c-api/gcc-callgraph.c
+++ b/gcc-c-api/gcc-callgraph.c
@@ -26,6 +26,8 @@
 #if (GCC_VERSION >= 5000)
 #include "gimple-expr.h"
 #endif
+#include "internal-fn.h"
+#include "gimple-expr.h"
 #include "gimple.h"
 
 /***********************************************************


### PR DESCRIPTION
4.9 moves the definitions of some gimple functions to new files that need to be
included first.