### PR TITLE
 Add support for PLUGIN_PRAGMA event to gcc-python-plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ PLUGIN_SOURCE_FILES= \
   gcc-python-option.c \
   gcc-python-parameter.c \
   gcc-python-pass.c \
+  gcc-python-pragma.c \
   gcc-python-pretty-printer.c \
   gcc-python-rtl.c \
   gcc-python-tree.c \

--- a/gcc-c-api/gcc-callgraph.c
+++ b/gcc-c-api/gcc-callgraph.c
@@ -23,9 +23,7 @@
 #include "ggc.h"
 #include "tree-ssa-alias.h"
 #include "basic-block.h"
-#if (GCC_VERSION >= 5000)
 #include "gimple-expr.h"
-#endif
 #include "gimple.h"
 
 /***********************************************************

--- a/gcc-python-callbacks.c
+++ b/gcc-python-callbacks.c
@@ -293,6 +293,17 @@ PyGcc_CallbackFor_GGC_END(void *gcc_data, void *user_data)
 					user_data);
 }
 
+static void
+PyGcc_CallbackFor_PRAGMAS(void *gcc_data, void *user_data)
+{
+    PyGILState_STATE gstate;
+
+    gstate = PyGILState_Ensure();
+
+    PyGcc_FinishInvokingCallback(gstate,
+					0, NULL,
+					user_data);
+}
 
 PyObject*
 PyGcc_RegisterCallback(PyObject *self, PyObject *args, PyObject *kwargs)
@@ -385,6 +396,13 @@ PyGcc_RegisterCallback(PyObject *self, PyObject *args, PyObject *kwargs)
 			  closure);
 	break;
 #endif /* GCC_PYTHON_PLUGIN_CONFIG_has_PLUGIN_FINISH_DECL */
+
+    case PLUGIN_PRAGMAS:
+        register_callback("python", // FIXME
+			  (enum plugin_event)event,
+			  PyGcc_CallbackFor_PRAGMAS,
+			  closure);
+        break;
 
     default:
         PyErr_Format(PyExc_ValueError, "event type %i invalid (or not wired up yet)", event);

--- a/gcc-python-callbacks.c
+++ b/gcc-python-callbacks.c
@@ -387,6 +387,13 @@ PyGcc_RegisterCallback(PyObject *self, PyObject *args, PyObject *kwargs)
 			  closure);
         break;
 
+    case PLUGIN_PRAGMAS:
+        register_callback("python", // FIXME
+			  (enum plugin_event)event,
+			  PyGcc_CallbackFor_PRAGMAS,
+			  closure);
+        break;
+
     /* PLUGIN_FINISH_DECL was added in gcc 4.7 onwards: */
 #ifdef GCC_PYTHON_PLUGIN_CONFIG_has_PLUGIN_FINISH_DECL
     case PLUGIN_FINISH_DECL:
@@ -396,13 +403,6 @@ PyGcc_RegisterCallback(PyObject *self, PyObject *args, PyObject *kwargs)
 			  closure);
 	break;
 #endif /* GCC_PYTHON_PLUGIN_CONFIG_has_PLUGIN_FINISH_DECL */
-
-    case PLUGIN_PRAGMAS:
-        register_callback("python", // FIXME
-			  (enum plugin_event)event,
-			  PyGcc_CallbackFor_PRAGMAS,
-			  closure);
-        break;
 
     default:
         PyErr_Format(PyExc_ValueError, "event type %i invalid (or not wired up yet)", event);

--- a/gcc-python-pragma.c
+++ b/gcc-python-pragma.c
@@ -7,24 +7,30 @@
 #include "plugin.h"
 #include <c-family/c-pragma.h> 
 
+void pragma_callback(struct cpp_reader * cpp_reader, void * data) {
+    PyObject * callback = (PyObject *) data;
+    PyObject_CallObject(callback, NULL);
+}
+
 PyObject*
-PyGcc_CRegisterPragma(PyObject *self, PyObject *args, PyObject *kwargs)
+PyGcc_CRegisterPragma(PyObject *self, PyObject *args)
 {
+    printf("%s\n", __FUNCTION__);
+
     const char *directive_space = NULL;
     const char *directive = NULL;
     PyObject *callback = NULL;
+    //PyObject dummy;
 
     if (!PyArg_ParseTuple(args,
                           "ssO:c_register_pragma",
                           &directive_space,
                           &directive,
                           &callback)) {
-        printf("error %s\n", __FUNCTION__);
         return NULL;
     }
 
-    // TODO: error here. how do we pass a python callback to gcc?
-    c_register_pragma(directive_space, directive, (pragma_handler_1arg)callback);
-    
+    c_register_pragma_with_data(directive_space, directive, pragma_callback, (void *) callback);
+
     Py_RETURN_NONE;
 }

--- a/gcc-python-pragma.c
+++ b/gcc-python-pragma.c
@@ -1,0 +1,30 @@
+// TODO: copyright stuff
+
+#include <Python.h>
+#include "gcc-python.h"
+#include "gcc-python-wrappers.h"
+
+#include "plugin.h"
+#include <c-family/c-pragma.h> 
+
+PyObject*
+PyGcc_CRegisterPragma(PyObject *self, PyObject *args, PyObject *kwargs)
+{
+    const char *directive_space = NULL;
+    const char *directive = NULL;
+    PyObject *callback = NULL;
+
+    if (!PyArg_ParseTuple(args,
+                          "ssO:c_register_pragma",
+                          &directive_space,
+                          &directive,
+                          &callback)) {
+        printf("error %s\n", __FUNCTION__);
+        return NULL;
+    }
+
+    // TODO: error here. how do we pass a python callback to gcc?
+    c_register_pragma(directive_space, directive, (pragma_handler_1arg)callback);
+    
+    Py_RETURN_NONE;
+}

--- a/gcc-python-pragma.c
+++ b/gcc-python-pragma.c
@@ -1,4 +1,9 @@
-// TODO: copyright stuff
+/*
+   FIXME: copyright stuff
+   FIXME: implement support for c_register_pragma_with_data,
+          c_register_pragma_with_expansion,
+          c_register_pragma_with_expansion_and_data
+ */
 
 #include <Python.h>
 #include "gcc-python.h"
@@ -7,20 +12,24 @@
 #include "plugin.h"
 #include <c-family/c-pragma.h> 
 
-void pragma_callback(struct cpp_reader * cpp_reader, void * data) {
-    PyObject * callback = (PyObject *) data;
+void handle_python_pragma(struct cpp_reader *cpp_reader, void *data) {
+    PyObject * callback = (PyObject*)data;
+
+    /* Debug code: */
+    if (0) {
+        printf("handle_python_pragma called\n");
+        fprintf(stderr, "cpp_reader: %p\n", cpp_reader);
+    }
+
     PyObject_CallObject(callback, NULL);
 }
 
 PyObject*
 PyGcc_CRegisterPragma(PyObject *self, PyObject *args)
 {
-    printf("%s\n", __FUNCTION__);
-
     const char *directive_space = NULL;
     const char *directive = NULL;
     PyObject *callback = NULL;
-    //PyObject dummy;
 
     if (!PyArg_ParseTuple(args,
                           "ssO:c_register_pragma",
@@ -30,7 +39,7 @@ PyGcc_CRegisterPragma(PyObject *self, PyObject *args)
         return NULL;
     }
 
-    c_register_pragma_with_data(directive_space, directive, pragma_callback, (void *) callback);
+    c_register_pragma_with_data(directive_space, directive, pragma_callback, (void*)callback);
 
     Py_RETURN_NONE;
 }

--- a/gcc-python-wrappers.h
+++ b/gcc-python-wrappers.h
@@ -131,6 +131,10 @@ PyGcc_inform(PyObject *self, PyObject *args, PyObject *kwargs);
 extern PyObject *
 PyGccPass_New(struct opt_pass *pass);
 
+/* gcc-python-pragmas.c */
+PyObject*
+PyGcc_CRegisterPragma(PyObject *self, PyObject *args, PyObject *kwargs);
+
 /* gcc-python-location.c: */
 PyObject *
 PyGccLocation_repr(struct PyGccLocation * self);

--- a/gcc-python-wrappers.h
+++ b/gcc-python-wrappers.h
@@ -131,9 +131,9 @@ PyGcc_inform(PyObject *self, PyObject *args, PyObject *kwargs);
 extern PyObject *
 PyGccPass_New(struct opt_pass *pass);
 
-/* gcc-python-pragmas.c */
+/* gcc-python-pragma.c */
 PyObject*
-PyGcc_CRegisterPragma(PyObject *self, PyObject *args, PyObject *kwargs);
+PyGcc_CRegisterPragma(PyObject *self, PyObject *args);
 
 /* gcc-python-location.c: */
 PyObject *

--- a/gcc-python.c
+++ b/gcc-python.c
@@ -400,6 +400,11 @@ static PyMethodDef GccMethods[] = {
      (METH_VARARGS | METH_KEYWORDS),
      "Pre-define a named value in the preprocessor."},
 
+    {"c_register_pragma",
+     (PyCFunction)PyGcc_CRegisterPragma,
+     (METH_VARARGS | METH_KEYWORDS),
+     "Register a callback for whenever a user defined pragma is parsed."},
+
     /* Diagnostics: */
     {"permerror", PyGcc_permerror, METH_VARARGS,
      NULL},

--- a/gcc-python.c
+++ b/gcc-python.c
@@ -402,7 +402,7 @@ static PyMethodDef GccMethods[] = {
 
     {"c_register_pragma",
      (PyCFunction)PyGcc_CRegisterPragma,
-     (METH_VARARGS | METH_KEYWORDS),
+     METH_VARARGS,
      "Register a callback for whenever a user defined pragma is parsed."},
 
     /* Diagnostics: */

--- a/tests/cpychecker/absinterp/comparisons/conditionals/stdout.txt
+++ b/tests/cpychecker/absinterp/comparisons/conditionals/stdout.txt
@@ -23,4 +23,4 @@ Trace 0:
     'taking True path'
     'returning'
   Exception:
-    (struct PyObject *)0 from tests/cpychecker/absinterp/comparisons/conditionals/input.c:29
+    (struct PyObject *)0 from tests/cpychecker/absinterp/comparisons/conditionals/input.c:32

--- a/tests/plugin/rtl/stdout.txt
+++ b/tests/plugin/rtl/stdout.txt
@@ -13,7 +13,7 @@ class Rtl(__builtin__.object)
  |  Data descriptors defined here:
  |  
  |  loc
- |      Source code location of this expression, as a gcc.Location
+ |      Source code location of this instruction, as a gcc.Location
  |  
  |  operands
  |      Operands of this expression, as a tuple


### PR DESCRIPTION
I will do cleanup with low priority and let you know via this pull request when I believe it is at a state acceptable for review.

Note, the following changes were needed for updating to GCC 4.9.2-6.
- tests/cpychecker/absinterp/comparisons/conditionals/stdout.txt
- tests/plugin/rtl/stdout.txt
- gcc-c-api/gcc-callgraph.c