### PR TITLE
fix include for gcc 4.9.2

### DIFF
--- a/gcc-c-api/gcc-callgraph.c
+++ b/gcc-c-api/gcc-callgraph.c
@@ -23,7 +23,7 @@
 #include "ggc.h"
 #include "tree-ssa-alias.h"
 #include "basic-block.h"
-#if (GCC_VERSION >= 5000)
+#if (GCC_VERSION >= 4009)
 #include "gimple-expr.h"
 #endif
 #include "gimple.h"


### PR DESCRIPTION
I needed this to build on Fedora 21.  It follows some other similar #ifs elsewhere.