### PR TITLE
Qualifier changes

### DIFF
--- a/docs/tree.rst
+++ b/docs/tree.rst
@@ -421,6 +421,33 @@ Types
       .. note:: This attribute is not usable from within `lto1`; attempting
          to use it there will lead to a `RuntimeError` exception.
 
+Additional attributes for various :py:class:`gcc.Type` subclasses:
+
+   .. py:attribute:: const
+
+      (Boolean) Does this type have the `const` modifier?
+
+   .. py:attribute:: const_equivalent
+
+      The :py:class:`gcc.Type` for the `const` version of this type
+
+   .. py:attribute:: volatile
+
+      (Boolean) Does this type have the `volatile` modifier?
+
+   .. py:attribute:: volatile_equivalent
+
+      The :py:class:`gcc.Type` for the `volatile` version of this type
+
+   .. py:attribute:: restrict
+
+      (Boolean) Does this type have the `restrict` modifier?
+
+   .. py:attribute:: restrict_equivalent
+
+      The :py:class:`gcc.Type` for the `restrict` version of this type
+
+
    The standard C types are accessible via class methods of :py:class:`gcc.Type`.
    They are only created by GCC after plugins are loaded, and so they're
    only visible during callbacks, not during the initial run of the code.
@@ -548,33 +575,6 @@ Types
    .. py:attribute:: dereference
 
       The :py:class:`gcc.Type` that this type points to
-
-Additional attributes for various :py:class:`gcc.Type` subclasses:
-
-   .. py:attribute:: const
-
-      (Boolean) Does this type have the `const` modifier?
-
-   .. py:attribute:: const_equivalent
-
-      The :py:class:`gcc.Type` for the `const` version of this type
-
-   .. py:attribute:: volatile
-
-      (Boolean) Does this type have the `volatile` modifier?
-
-   .. py:attribute:: volatile_equivalent
-
-      The :py:class:`gcc.Type` for the `volatile` version of this type
-
-   .. py:attribute:: restrict
-
-      (Boolean) Does this type have the `restrict` modifier?
-
-   .. py:attribute:: restrict_equivalent
-
-      The :py:class:`gcc.Type` for the `restrict` version of this type
-
 
 .. py:class:: gcc.FunctionType
 

--- a/docs/tree.rst
+++ b/docs/tree.rst
@@ -447,6 +447,11 @@ Additional attributes for various :py:class:`gcc.Type` subclasses:
 
       The :py:class:`gcc.Type` for the `restrict` version of this type
 
+   .. py:attribute:: unqualified_equivalent
+
+      The :py:class:`gcc.Type` for the version of this type that does
+      not have any qualifiers.
+
 
    The standard C types are accessible via class methods of :py:class:`gcc.Type`.
    They are only created by GCC after plugins are loaded, and so they're

--- a/generate-tree-c.py
+++ b/generate-tree-c.py
@@ -398,6 +398,9 @@ def generate_tree_code_classes():
                 add_simple_getter('%s_equivalent' % qual,
                                   'PyGccTree_New(gcc_private_make_tree(build_qualified_type(self->t.inner, TYPE_QUALS(self->t.inner) | TYPE_QUAL_%s)))' % qual.upper(),
                                   'The gcc.Type for the %s version of this type' % qual)
+            add_simple_getter('unqualified_equivalent',
+                              'PyGccTree_New(gcc_private_make_tree(build_qualified_type(self->t.inner, 0)))',
+                                  'The gcc.Type for the unqualified version of this type')
         if tree_type.SYM == 'RECORD_TYPE':
             add_simple_getter('const',
                               'PyBool_FromLong(TYPE_READONLY(self->t.inner))',

--- a/generate-tree-c.py
+++ b/generate-tree-c.py
@@ -396,7 +396,7 @@ def generate_tree_code_classes():
                                   'PyBool_FromLong(TYPE_QUALS(self->t.inner) & TYPE_QUAL_%s)' % qual.upper(),
                                   "Boolean: does this type have the '%s' modifier?" % qual)
                 add_simple_getter('%s_equivalent' % qual,
-                                  'PyGccTree_New(gcc_private_make_tree(build_qualified_type(self->t.inner, TYPE_QUAL_%s)))' % qual.upper(),
+                                  'PyGccTree_New(gcc_private_make_tree(build_qualified_type(self->t.inner, TYPE_QUALS(self->t.inner) | TYPE_QUAL_%s)))' % qual.upper(),
                                   'The gcc.Type for the %s version of this type' % qual)
         if tree_type.SYM == 'RECORD_TYPE':
             add_simple_getter('const',

--- a/tests/plugin/types/script.py
+++ b/tests/plugin/types/script.py
@@ -43,6 +43,7 @@ def on_finish_unit():
     print(gcc.Type.char().const_equivalent.const)
     print(gcc.Type.char().const_equivalent.restrict_equivalent.const)
     print(gcc.Type.char().const_equivalent.volatile_equivalent.const)
+    print(gcc.Type.char().const_equivalent.volatile_equivalent.unqualified_equivalent.const)
 
     def dump_real_type(t):
         print('gcc.Type: %r' % str(t))

--- a/tests/plugin/types/script.py
+++ b/tests/plugin/types/script.py
@@ -39,6 +39,11 @@ def on_finish_unit():
     dump_integer_type(gcc.Type.unsigned_char())
     dump_integer_type(gcc.Type.signed_char())
 
+    print(gcc.Type.char().const)
+    print(gcc.Type.char().const_equivalent.const)
+    print(gcc.Type.char().const_equivalent.restrict_equivalent.const)
+    print(gcc.Type.char().const_equivalent.volatile_equivalent.const)
+
     def dump_real_type(t):
         print('gcc.Type: %r' % str(t))
         print('  t.const: %r' % t.const)

--- a/tests/plugin/types/stdout.txt
+++ b/tests/plugin/types/stdout.txt
@@ -12,6 +12,10 @@ gcc.Type: 'signed char'
   t.min_value.constant: -128
   t.max_value.constant: 127
   t.sizeof: 1
+False
+True
+True
+True
 gcc.Type: 'float'
   t.const: False
   t.precision: 32

--- a/tests/plugin/types/stdout.txt
+++ b/tests/plugin/types/stdout.txt
@@ -16,6 +16,7 @@ False
 True
 True
 True
+False
 gcc.Type: 'float'
   t.const: False
   t.precision: 32


### PR DESCRIPTION
This clarifies the gcc.Type documentation a little, fixes a bug with qualifiers, and adds a way to get the unqualified variant of a type