### PR TITLE
Don't include gimple.h for GCC >= 4.9, include only gimple-expr.h

### DIFF
--- a/gcc-c-api/gcc-callgraph.c
+++ b/gcc-c-api/gcc-callgraph.c
@@ -25,8 +25,9 @@
 #include "basic-block.h"
 #if (GCC_VERSION >= 4009)
 #include "gimple-expr.h"
-#endif
+#else
 #include "gimple.h"
+#endif
 
 /***********************************************************
    gcc_cgraph_node


### PR DESCRIPTION
Tested on gcc 4.9.3 and gcc 4.8.4 Ubuntu 14.04.
