### PR TITLE
Filter out -flto from sysconfig's CFLAGS

### DIFF
--- a/testcpybuilder.py
+++ b/testcpybuilder.py
@@ -73,7 +73,13 @@ class BuiltModule:
         self.args += ['-o', self.modfile]
         self.args +=  ['-I' + sc.get_python_inc(),
                        '-I' + sc.get_python_inc(plat_specific=True)]
-        self.args += sc.get_config_var('CFLAGS').split()
+
+        # Get CFLAGS from sysconfig
+        cflags = sc.get_config_var('CFLAGS').split()
+        # Filter out LTO
+        cflags = filter(lambda flag: flag != '-flto', cflags)
+        self.args += cflags
+
         self.args += ['-Wall',  '-Werror'] # during testing
         # on some builds of Python, CFLAGS does not contain -fPIC, but it
         # appears to still be necessary:


### PR DESCRIPTION
An rpm build was failing during %test with Python 3.7, built with LTO, due
to "-flto" coming in from sysconfig's CFLAGS in
testcpybuilder.BuiltModule.compile_src, and thus the plugin
unexpectedly running from within lto1 (and failing).

Filter out any "-flto" in testcpybuilder.BuiltModule

+ python3 testcpychecker.py -v

======================================================================
ERROR: test_correct_usage (__main__.PyArg_ParseTupleAndKeywordsTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "testcpychecker.py", line 223, in test_correct_usage
    self.assertNoErrors(src)
  File "testcpychecker.py", line 88, in assertNoErrors
    self.build_module(bm)
  File "testcpychecker.py", line 79, in build_module
    self.compile_src(bm)
  File "testcpychecker.py", line 75, in compile_src
    bm.compile_src(extra_cflags)
  File "/builddir/build/BUILD/gcc-python-plugin-0.16/building-for-python3/testcpybuilder.py", line 98, in compile_src
    raise CompilationError(self)
testcpybuilder.CompilationError:
returncode: 1
  compiling: gcc -o /tmp/tmpo4qiynz3/example.cpython-37m-x86_64-linux-gnu.so -I/usr/include/python3.7m -I/usr/include/python3.7m -Wno-unused-result -Wsign-compare -DDYNAMIC_ANNOTATIONS_ENABLED=1 -DNDEBUG -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -D_GNU_SOURCE -fPIC -fwrapv -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -D_GNU_SOURCE -fPIC -fwrapv -flto -fuse-linker-plugin -ffat-lto-objects -flto-partition=none -Wall -Werror -fPIC -shared -fplugin=/builddir/build/BUILD/gcc-python-plugin-0.16/building-for-python3/python3.so -fplugin-arg-python3-script=cpychecker.py -fno-diagnostics-show-caret /tmp/tmpo4qiynz3/example.c
Stdout:
Stderr:
    <built-in>: error: Unhandled Python exception raised within callback
    Traceback (most recent call last):
      File "/builddir/build/BUILD/gcc-python-plugin-0.16/building-for-python3/libcpychecker/attributes.py", line 54, in register_our_attributes
        gcc.define_macro('WITH_CPYCHECKER_RETURNS_BORROWED_REF_ATTRIBUTE')
    ValueError: gcc.define_macro("WITH_CPYCHECKER_RETURNS_BORROWED_REF_ATTRIBUTE") called without a compilation unit
    lto1: fatal error: errors during merging of translation units
    compilation terminated.
    lto-wrapper: fatal error: gcc returned 1 exit status
    compilation terminated.
    /usr/bin/ld: error: lto-wrapper failed
    collect2: error: ld returned 1 exit status