### PR TITLE
[v2] Makefile: Verify demo run for target test-suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -290,10 +290,17 @@ debug: plugin
 demo: plugin
 	$(INVOCATION_ENV_VARS) $(srcdir)./gcc-with-cpychecker -c $(PYTHON_INCLUDES) demo.c
 
+# Run 'demo', and verify the output.
+testdemo: plugin
+	$(MAKE) demo > demo.output 2> demo.err
+	grep '^demo.c:' demo.err > demo.filtered
+	diff demo.filtered demo.expected
+	rm demo.output demo.err demo.filtered
+
 json-examples: plugin
 	$(INVOCATION_ENV_VARS) $(srcdir)./gcc-with-cpychecker -I/usr/include/python2.7 -c libcpychecker_html/test/example1/bug.c
 
-test-suite: plugin print-gcc-version testdejagnu
+test-suite: plugin print-gcc-version testdejagnu testdemo
 	$(INVOCATION_ENV_VARS) $(PYTHON) run-test-suite.py
 
 show-ssa: plugin

--- a/demo.expected
+++ b/demo.expected
@@ -1,0 +1,13 @@
+demo.c: In function ‘socket_htons’:
+demo.c:30:10: warning: Mismatching type in call to PyArg_ParseTuple with format code "i:htons"
+demo.c: In function ‘not_enough_varargs’:
+demo.c:40:9: warning: Not enough arguments in call to PyArg_ParseTuple with format string "i"
+demo.c: In function ‘too_many_varargs’:
+demo.c:50:10: warning: Too many arguments in call to PyArg_ParseTuple with format string "i"
+demo.c: In function ‘kwargs_example’:
+demo.c:62:10: warning: Mismatching type in call to PyArg_ParseTupleAndKeywords with format code "(ff):kwargs_example"
+demo.c:62:10: warning: Mismatching type in call to PyArg_ParseTupleAndKeywords with format code "(ff):kwargs_example"
+demo.c: In function ‘buggy_converter’:
+demo.c:76:10: warning: Mismatching type in call to PyArg_ParseTuple with format code "O&"
+demo.c: In function ‘make_a_list_of_random_ints_badly’:
+demo.c:90:10: warning: Mismatching type in call to PyArg_ParseTuple with format code "i"


### PR DESCRIPTION
When running make with default target all, we run test targets testcpybuilder,
testdejagnu, test-suite and testcpychecker, but none of those excercises
gcc-with-cpychecker.

Add a target testdemo, which runs the demo target (which excercises
gcc-with-cpychecker) and verifies the output.

[ The demo fails for me with verify_refcounting=True, so demo.expected is
generated with verify_refcounting=False.  That file needs to be fixed up with
the missing verify_refcounting related lines. ]