### PR TITLE
libcpychecker: Switch off verify_refcounting for gcc-7 and later

### DIFF
--- a/gcc-with-cpychecker
+++ b/gcc-with-cpychecker
@@ -70,6 +70,7 @@ if 0:
 # but unfortunately gcc's option parser seems to not be able to cope with '='
 # within an option's value.  So we do it using dictionary syntax instead:
 dictstr = '"verify_refcounting":True'
+dictstr += ', "verbose":True'
 dictstr += ', "maxtrans":%i' % ns.maxtrans
 dictstr += ', "dump_json":%i' % ns.dump_json
 cmd = 'from libcpychecker import main; main(**{%s})' % dictstr


### PR DESCRIPTION
Refcounting verification fails in some cases for gcc-7 and later.

Workaround this by disabling refcounting verification entirely for gcc-7 and
later, to make sure that users don't run into python exceptions.

Emit warning in gcc-with-cpychecker when refcounting verification has been
disabled, to make sure that users are aware of this.