### PR TITLE
demo.c: Update for python3

### DIFF
--- a/demo.c
+++ b/demo.c
@@ -22,6 +22,12 @@
 
 extern uint16_t htons(uint16_t hostshort);
 
+#if PY_MAJOR_VERSION >= 3
+#define PYINT_FROMLONG(l) (PyLong_FromLong(l))
+#else
+#define PYINT_FROMLONG(l) (PyInt_FromLong(l))
+#endif
+
 PyObject *
 socket_htons(PyObject *self, PyObject *args)
 {
@@ -31,7 +37,7 @@ socket_htons(PyObject *self, PyObject *args)
         return NULL;
     }
     x2 = (int)htons((short)x1);
-    return PyInt_FromLong(x2);
+    return PYINT_FROMLONG(x2);
 }
 
 PyObject *


### PR DESCRIPTION
Test-case demo.c does not compile with python3, because it uses a PyInt_*
function.

Fix compilation by replacing it with its PyLong_* equivalent, as suggested by
this ( https://docs.python.org/3/howto/cporting.html#long-int-unification ).