### PR TITLE
gcc-with-cpychecker: Add --cpychecker-verbose

### DIFF
--- a/gcc-with-cpychecker
+++ b/gcc-with-cpychecker
@@ -57,6 +57,11 @@ parser.add_argument('--dump-json',
                           ' "foo.c.bar.json" will be written out in JSON'
                           ' form'))
 
+parser.add_argument('--cpychecker-verbose',
+                    action='store_true',
+                    default=False,
+                    help=('Output extra information'))
+
 # Only consume args we understand, leaving the rest for gcc:
 ns, other_args = parser.parse_known_args()
 if 0:
@@ -70,7 +75,7 @@ if 0:
 # but unfortunately gcc's option parser seems to not be able to cope with '='
 # within an option's value.  So we do it using dictionary syntax instead:
 dictstr = '"verify_refcounting":True'
-dictstr += ', "verbose":True'
+dictstr += ', "verbose":%i' % (ns.cpychecker_verbose)
 dictstr += ', "maxtrans":%i' % ns.maxtrans
 dictstr += ', "dump_json":%i' % ns.dump_json
 cmd = 'from libcpychecker import main; main(**{%s})' % dictstr


### PR DESCRIPTION
In "libcpychecker: Switch off verify_refcounting for gcc-7 and later", we
added a warning in gcc-with-cpychecker when refcounting verification has been
disabled.

This warning causes configure tests of gdb to fail when building using
{CC,CXX}=gcc-with-cpychecker.

Fix this by switching the warning off by default, and adding an option
--cpychecker-verbose to switch it on.

[ An alternative could be to change the syntax from:
  gcc-with-cpychecker [options] gcc-options
to:
  gcc-with-cpychecker [options --] gcc-options
and use:
  gcc-with-cpychecker --verbose --
instead of:
  gcc-with-cpychecker --cpychecker-verbose
]