### PR TITLE
expose DECL_ORIGINAL_TYPE (for typedefs)

### DIFF
--- a/gcc-python-tree.c
+++ b/gcc-python-tree.c
@@ -831,6 +831,17 @@ PyGccTypeDecl_get_pointer(struct PyGccTree *self, void *closure)
 }
 
 PyObject *
+PyGccTypeDecl_get_original_type(struct PyGccTree *self, void *closure)
+{
+    tree decl_type = TREE_TYPE(self->t.inner);
+    if (!decl_type) {
+        PyErr_SetString(PyExc_ValueError, "gcc.TypeDecl has no associated type");
+        return NULL;
+    }
+    return PyGccTree_New(gcc_private_make_tree(DECL_ORIGINAL_TYPE(TYPE_NAME(decl_type))));
+}
+
+PyObject *
 PyGccSsaName_repr(struct PyGccTree * self)
 {
     int version;

--- a/gcc-python-wrappers.h
+++ b/gcc-python-wrappers.h
@@ -326,6 +326,9 @@ PyObject *
 PyGccTypeDecl_get_pointer(struct PyGccTree *self, void *closure);
 
 PyObject *
+PyGccTypeDecl_get_original_type(struct PyGccTree *self, void *closure);
+
+PyObject *
 PyGccSsaName_repr(struct PyGccTree * self);
 
 PyObject *

--- a/generate-tree-c.py
+++ b/generate-tree-c.py
@@ -545,6 +545,10 @@ def generate_tree_code_classes():
                                   'PyGccTypeDecl_get_pointer',
                                   None,
                                   "The gcc.PointerType representing '(this_type *)'")
+            getsettable.add_gsdef('original_type',
+                                  'PyGccTypeDecl_get_original_type',
+                                  None,
+                                  "The gcc.Type from which this type was typedef'd from.'")
 
         if tree_type.SYM == 'FUNCTION_TYPE':
             getsettable.add_gsdef('argument_types',

--- a/tests/plugin/types/input.c
+++ b/tests/plugin/types/input.c
@@ -17,3 +17,5 @@
    <http://www.gnu.org/licenses/>.
 */
 
+typedef int mytype;
+typedef mytype nestedtype;

--- a/tests/plugin/types/script.py
+++ b/tests/plugin/types/script.py
@@ -55,5 +55,18 @@ def on_finish_unit():
     dump_real_type(gcc.Type.float())
     dump_real_type(gcc.Type.double())
 
+    def dump_typedef(td):
+        t = td.type
+        print('gcc.TypeDecl: %r' % str(td))
+        print('  td.original_type: %r' % td.original_type)
+        print('  td.original_type is gcc.Type.int(): %r' % (td.original_type is gcc.Type.int()))
+        mytype = gccutils.get_global_typedef('mytype')
+        print('  td.original_type.name: %r' % td.original_type.name)
+        print('  td.original_type.name is mytype: %r' % (td.original_type.name is mytype))
+        dump_integer_type(t)
+
+    dump_typedef(gccutils.get_global_typedef('mytype'))
+    dump_typedef(gccutils.get_global_typedef('nestedtype'))
+
 gcc.register_callback(gcc.PLUGIN_FINISH_UNIT,
                       on_finish_unit)

--- a/tests/plugin/types/stdout.txt
+++ b/tests/plugin/types/stdout.txt
@@ -25,3 +25,27 @@ gcc.Type: 'double'
   t.const: False
   t.precision: 64
   t.sizeof: 8
+gcc.TypeDecl: 'mytype'
+  td.original_type: gcc.IntegerType(name=gcc.TypeDecl('int'))
+  td.original_type is gcc.Type.int(): True
+  td.original_type.name: gcc.TypeDecl('int')
+  td.original_type.name is mytype: False
+gcc.Type: 'mytype'
+  t.const: False
+  t.unsigned: False
+  t.precision: 32
+  t.min_value.constant: -2147483648
+  t.max_value.constant: 2147483647
+  t.sizeof: 4
+gcc.TypeDecl: 'nestedtype'
+  td.original_type: gcc.IntegerType(name=gcc.TypeDecl('mytype'))
+  td.original_type is gcc.Type.int(): False
+  td.original_type.name: gcc.TypeDecl('mytype')
+  td.original_type.name is mytype: True
+gcc.Type: 'nestedtype'
+  t.const: False
+  t.unsigned: False
+  t.precision: 32
+  t.min_value.constant: -2147483648
+  t.max_value.constant: 2147483647
+  t.sizeof: 4


### PR DESCRIPTION
This is a rebase/respin of #25 which is desperately needed.  Without this, it's impossible to figure out what a `typedef` is defined to.

Code is originally by @bloff - I just rebased it and added a small test.