### PR TITLE
gcc-python-pretty-printer: fix GCC 8.3 compatibility

### DIFF
--- a/gcc-python-pretty-printer.c
+++ b/gcc-python-pretty-printer.c
@@ -46,7 +46,7 @@ PyGccPrettyPrinter_New(void)
        Use placement new to run it on obj->pp.  */
     new ((void*)&obj->pp)
         pretty_printer(
-# if (GCC_VERSION < 9000)
+# if (GCC_VERSION < 8003)
                        /* GCC 9 eliminated the "prefix" param.  */
                        NULL,
 # endif


### PR DESCRIPTION
GCC 8.3 eliminated the prefix parameter as well as GCC 9. This patch
is based on the diff posted by @doko42 in davidmalcolm#173.