### PR TITLE
Update gcc-python-wrapper.c for Python 3.8

### DIFF
--- a/gcc-python-wrapper.c
+++ b/gcc-python-wrapper.c
@@ -137,7 +137,11 @@ PyTypeObject PyGccWrapperMeta_TypeObj  = {
     sizeof(PyGccWrapperTypeObject), /*tp_basicsize*/
     0, /*tp_itemsize*/
     NULL, /* tp_dealloc */
+#if PY_VERSION_HEX >= 0x03080000
+    0, /*tp_vectorcall_offset*/
+#else
     NULL, /* tp_print */
+#endif
     NULL, /* tp_getattr */
     NULL, /* tp_setattr */
 #if PY_MAJOR_VERSION < 3


### PR DESCRIPTION
Commit 3a4b484eaeda ("Build on Python 3.8") updated `cpybuilder.py` but not `gcc-python-wrapper.c`. This results in the following error when building with Python 3.8:

    gcc-python-wrapper.c:188:1: error: converting to non-pointer type
    ‘long int’ from NULL [-Werror=conversion-null]
      188 | };
          | ^