### PR TITLE
Link with libpython3.8.so

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ PYTHON_CONFIG=python-config
 #PYTHON_CONFIG=python3.3dm-config
 
 PYTHON_INCLUDES=$(shell $(PYTHON_CONFIG) --includes)
-PYTHON_LIBS=$(shell $(PYTHON_CONFIG) --libs)
+PYTHON_LIBS=$(shell $(PYTHON) -c 'import sys;print("-lpython%d.%d" % sys.version_info[:2])') $(shell $(PYTHON_CONFIG) --libs)
 
 # Support having multiple named plugins
 # e.g. "python2.7" "python3.2mu" "python 3.2dmu" etc:


### PR DESCRIPTION
Since Python 3.8, `python-config --libs` no longer includes `/usr/lib/libpython3.8.so` in the linked libraries. This results in the following error when using plugins, for example in `make man`:

    PYTHONPATH=./ CC_FOR_CPYCHECKER=cc LD_LIBRARY_PATH=gcc-c-api:
    CC=cc ./gcc-with-python generate-passes-svg.py test.c
    cc1: error: cannot load plugin
    /usr/src/gcc-python-plugin/src/gcc-python-plugin-0.17/python.so
       /usr/src/gcc-python-plugin/src/gcc-python-plugin-0.17/python.so: undefined symbol:
    PyUnicode_FromFormat

Fix this by adding `-lpython3.8` to `$(PYTHON_LIBS)` in `Makefile`.