### PR TITLE
DRAFT removing the Wrapper metaclass for python 3.9. resolves TypeError: 'gcc.WrapperMeta' object is not iterable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,9 +90,9 @@ GENERATOR_DEPS=cpybuilder.py wrapperbuilder.py print-gcc-version
 #    make  PYTHON=python3  PYTHON_CONFIG=python3-config  all
 
 # The python interpreter to use:
-PYTHON=python
+PYTHON=~/.pyenv/versions/3.9-dev/bin/python3
 # The python-config executable to use:
-PYTHON_CONFIG=python-config
+PYTHON_CONFIG=~/.pyenv/versions/3.9-dev/bin/python3-config
 
 #PYTHON=python3
 #PYTHON_CONFIG=python3-config
@@ -105,6 +105,9 @@ PYTHON_CONFIG=python-config
 
 PYTHON_INCLUDES=$(shell $(PYTHON_CONFIG) --includes)
 PYTHON_LIBS=$(shell $(PYTHON) -c 'import sys;print("-lpython%d.%d" % sys.version_info[:2])') $(shell $(PYTHON_CONFIG) --libs)
+
+#PYTHON_LDFLAGS=$(shell $(PYTHON_CONFIG) --ldflags)
+PYTHON_LDFLAGS=-L/root/.pyenv/versions/3.9-dev/lib/python3.9/config-3.9-x86_64-linux-gnu -L/root/.pyenv/versions/3.9-dev/lib  -lcrypt -lpthread -ldl  -lutil -lm -lm 
 
 # Support having multiple named plugins
 # e.g. "python2.7" "python3.2mu" "python 3.2dmu" etc:
@@ -121,7 +124,8 @@ CPPFLAGS+= -I$(GCCPLUGINS_DIR)/include -I$(GCCPLUGINS_DIR)/include/c-family -I. 
 # and choose debugging information level.
 CFLAGS?=-O2 -Werror -g
 # Force these settings
-CFLAGS+= -fPIC -fno-strict-aliasing -Wall
+CFLAGS+= -fPIC# after any initial comment lines
+
 LIBS+= $(PYTHON_LIBS)
 ifneq "$(PLUGIN_PYTHONPATH)" ""
   CPPFLAGS+= -DPLUGIN_PYTHONPATH='"$(PLUGIN_PYTHONPATH)"'
@@ -147,7 +151,7 @@ INVOCATION_ENV_VARS := PYTHONPATH=$(srcdir)./ CC_FOR_CPYCHECKER=$(CC) LD_LIBRARY
 #
 $(PLUGIN_DSO): $(PLUGIN_OBJECT_FILES) $(LIBGCC_C_API_SO)
 	$(CC) \
-	    $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) \
+	    $(CPPFLAGS) $(CFLAGS) $(PYTHON_LDFLAGS) $(LDFLAGS) \
 	    -shared \
 	    $(PLUGIN_OBJECT_FILES) \
 	    -o $@ \

--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -219,7 +219,7 @@ Debugging your script
 ---------------------
 
 You can place a forced breakpoint in your script using this standard Python
-one-liner::
+one-lxiner::
 
    import pdb; pdb.set_trace()
 

--- a/gcc-python-option.c
+++ b/gcc-python-option.c
@@ -49,7 +49,7 @@ PyGccOption_init(PyGccOption * self, PyObject *args, PyObject *kwargs)
     /*
       We need to call _track manually as we're not using PyGccWrapper_New():
     */
-    PyGccWrapper_Track(&self->head);
+    //PyGccWrapper_Track(&self->head);
 
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "s", (char**)kwlist,
                                       &text)) {

--- a/gcc-python-pass.c
+++ b/gcc-python-pass.c
@@ -283,7 +283,7 @@ do_pass_init(PyObject *s, PyObject *args, PyObject *kwargs,
     /*
       We need to call _track manually as we're not using PyGccWrapper_New():
     */
-    PyGccWrapper_Track(&self->head);
+    //PyGccWrapper_Track(&self->head);
 
     if (!PyArg_ParseTupleAndKeywords(args, kwargs,
                                      "s:gcc.Pass.__init__", (char**)keywords,
@@ -647,16 +647,16 @@ get_type_for_pass_type(enum opt_pass_type pt)
     default: assert(0);
 
     case GIMPLE_PASS:
-	return &PyGccGimplePass_TypeObj;
+        return &PyGccGimplePass_TypeObj;
 
     case RTL_PASS:
-	return &PyGccRtlPass_TypeObj;
+        return &PyGccRtlPass_TypeObj;
 
     case SIMPLE_IPA_PASS:
-	return &PyGccSimpleIpaPass_TypeObj;
+        return &PyGccSimpleIpaPass_TypeObj;
 
     case IPA_PASS:
-	return &PyGccIpaPass_TypeObj;
+        return &PyGccIpaPass_TypeObj;
     }
 };
 
@@ -669,7 +669,7 @@ real_make_pass_wrapper(void *p)
     struct PyGccPass *pass_obj = NULL;
 
     if (NULL == pass) {
-	Py_RETURN_NONE;
+        Py_RETURN_NONE;
     }
 
     type_obj = get_type_for_pass_type(pass->type);
@@ -683,7 +683,7 @@ real_make_pass_wrapper(void *p)
     /* FIXME: do we need to do something for the GCC GC? */
 
     return (PyObject*)pass_obj;
-      
+
 error:
     return NULL;
 }
@@ -702,12 +702,12 @@ PyObject *
 PyGccPass_New(struct opt_pass *pass)
 {
     return PyGcc_LazilyCreateWrapper(&pass_wrapper_cache,
-					    pass,
-					    real_make_pass_wrapper);
+                                            pass,
+                                            real_make_pass_wrapper);
 }
 
 /*
-  PEP-7  
+  PEP-7
 Local variables:
 c-basic-offset: 4
 indent-tabs-mode: nil

--- a/gcc-python.c
+++ b/gcc-python.c
@@ -794,7 +794,7 @@ plugin_init (struct plugin_name_args *plugin_info,
 
     PyGcc_globals.module = PyImport_ImportModule("gcc");
 
-    PyEval_InitThreads();
+    //    PyEval_InitThreads(); This is deprecated
   
     if (!PyGcc_init_gcc_module(plugin_info)) {
         return 1;
@@ -804,7 +804,7 @@ plugin_init (struct plugin_name_args *plugin_info,
         return 1;
     }
 
-    /* Init other modules */
+    /* Init otherOA modules */
     PyGcc_wrapper_init();
 
     /* FIXME: properly integrate them within the module hierarchy */

--- a/gcc-python.h
+++ b/gcc-python.h
@@ -148,10 +148,11 @@ extern PyTypeObject PyGccWrapperMeta_TypeObj;
     ARG_fieldname:
       the name of the field within the CPython struct, containing the pointer
       to the GCC data
+
+  struct PyGccWrapper head;
  */
 #define DECLARE_SIMPLE_WRAPPER(ARG_structname, ARG_typeobj, ARG_typename, ARG_wrappedtype, ARG_fieldname) \
   struct ARG_structname {           \
-     struct PyGccWrapper head;      \
      ARG_wrappedtype ARG_fieldname; \
   };                                \
                                     \

--- a/gcc-with-python
+++ b/gcc-with-python
@@ -16,4 +16,4 @@
 #   along with this program.  If not, see
 #   <http://www.gnu.org/licenses/>.
 
-${CC:-gcc} -fplugin=$(pwd)/python.so -fplugin-arg-python-script=$@
+gdb ${CC:-gcc} -fplugin=$(pwd)/python.so -fplugin-arg-python-script=$@

--- a/wrapperbuilder.py
+++ b/wrapperbuilder.py
@@ -30,7 +30,9 @@ class PyGccWrapperTypeObject(PyTypeObject):
     """
     def __init__(self, *args, **kwargs):
         PyTypeObject.__init__(self, *args, **kwargs)
-        self.ob_type = '&PyGccWrapperMeta_TypeObj'
+        # TODO make more dynamic here
+        # self.ob_type = '&PyGccWrapperMeta_TypeObj'
+        self.ob_type = 'NULL'
 
     def c_defn(self):
         result = '\n'


### PR DESCRIPTION
This code here is experimental.
I am using the docker image zbeekman/nightly-gcc-trunk-docker-image
latest 5114095361e6  with patches. gcc (GCC) 10.0.0
20191203 (experimental) latest 5114095361e6  I guess that
is actually older than I thought but whatever.
I am testing with pyenv 3.9-dev Python 3.9.9 .

The first thing I did was hook it up to the new python, then I had to
remove some deprecated code. Finally I worked around the issue of the
metaclass not loading. It does not even seem to be used so I am
removing it for now until I can learn more.

The goal here is to have a docker container that will contain the
latest version of the python plugin in a way that anyone can use it
easily with a docker pull.

Merry Christmas and Happy New Year 2020

mike